### PR TITLE
exchanging br elements for margin style rules, fixing navigation usin…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,56 +1,103 @@
 <template>
   <div id="app">
-    <div id="banner">
+    <header id="banner">
       <locale-changer></locale-changer>
-      <br>
-      <object data="invitation-Ezgi_Johannes_solobronze.svg" width="85%" height="200" style="max-width: 840px"></object>
-      <br>
-      <HelloWorld msg="Ezgi & Johannes"/>
+      <object
+        class="mt-1"
+        data="invitation-Ezgi_Johannes_solobronze.svg"
+        width="85%"
+        height="200"
+        style="max-width: 840px"
+      ></object>
+      <HelloWorld msg="Ezgi & Johannes" />
+    </header>
 
-    </div>
-    <br>
-    <div class="nav">
-      <router-link class="route-link" to="/invitation">{{ $t("message.rsvp") }}</router-link>
-      <router-link class="route-link" to="/how-to-get-there">{{ $t("message.arrive") }}</router-link>
-      <router-link class="route-link" to="/where-to-sleep">{{ $t("message.sleep") }}</router-link>
-      <router-link class="route-link" to="/schedule">{{ $t("message.schedule") }}</router-link>
-      <router-link class="route-link" to="/language">{{ $t("message.lang") }}</router-link>
-      <router-link class="route-link" to="/about">{{ $t("message.denizli") }}</router-link>
-      <router-link class="route-link" to="/gifts">{{ $t("message.gifts") }}</router-link>
-      <router-link class="route-link" to="/">{{ $t("message.invitation") }}</router-link>
+    <nav class="nav mb-2">
+      <router-link class="route-link" to="/invitation">{{
+        $t("message.rsvp")
+      }}</router-link>
+      <router-link class="route-link" to="/how-to-get-there">{{
+        $t("message.arrive")
+      }}</router-link>
+      <router-link class="route-link" to="/where-to-sleep">{{
+        $t("message.sleep")
+      }}</router-link>
+      <router-link class="route-link" to="/schedule">{{
+        $t("message.schedule")
+      }}</router-link>
+      <router-link class="route-link" to="/language">{{
+        $t("message.lang")
+      }}</router-link>
+      <router-link class="route-link" to="/about">{{
+        $t("message.denizli")
+      }}</router-link>
+      <router-link class="route-link" to="/gifts">{{
+        $t("message.gifts")
+      }}</router-link>
+      <router-link class="route-link" to="/">{{
+        $t("message.invitation")
+      }}</router-link>
+    </nav>
+    <main>
       <router-view></router-view>
-    </div>
+    </main>
     <div class="footer-container">
-      <img class="footer" src="invitation-small.svg"/>
+      <img class="footer" src="invitation-small.svg" />
     </div>
   </div>
 </template>
 
 <script>
-import HelloWorld from './components/Welcome.vue'
+import HelloWorld from "./components/Welcome.vue";
 import LocaleChanger from "@/components/LocaleChanger";
 
 export default {
-  name: 'App',
+  name: "App",
   components: {
     LocaleChanger,
-    HelloWorld
-  }
-}
+    HelloWorld,
+  },
+};
 </script>
 
 <style>
+/* important for layout consistency */
+* {
+  box-sizing: border-box;
+}
+
+/* like 1 <br> */
+.mb-1 {
+  margin-bottom: 23px;
+}
+.mt-1 {
+  margin-top: 23px;
+}
+/* like 2 <br> */
+.mb-2 {
+  margin-bottom: 46px;
+}
+.mt-2 {
+  margin-top: 46px;
+}
+
+/* main container */
+main {
+  max-width: 1080px;
+  padding: 15px;
+  margin: 0 auto;
+}
 
 #banner {
-  background: url('../public/aydin-hassan-rnOdgU4EEWU-unsplash.jpg');
+  background: url("../public/aydin-hassan-rnOdgU4EEWU-unsplash.jpg");
   width: 100%;
   min-height: 189px;
   z-index: -1;
-  border-bottom: solid rgba(175, 162, 104, 0.10) 2px;
-
+  border-bottom: solid rgba(175, 162, 104, 0.1) 2px;
+  margin-bottom: 23px;
 }
 
-@import url(http://fonts.googleapis.com/css?family=Source+Code+Pro:400,600);
+@import url(http://fonts.googleapis.com/css?family=Source+Code+Pro:400, 600);
 
 html {
   /*background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAyCAMAAAAp4XiDAAAAUVBMVEWFhYWDg4N3d3dtbW17e3t1dXWBgYGHh4d5eXlzc3OLi4ubm5uVlZWPj4+NjY19fX2JiYl/f39ra2uRkZGZmZlpaWmXl5dvb29xcXGTk5NnZ2c8TV1mAAAAG3RSTlNAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEAvEOwtAAAFVklEQVR4XpWWB67c2BUFb3g557T/hRo9/WUMZHlgr4Bg8Z4qQgQJlHI4A8SzFVrapvmTF9O7dmYRFZ60YiBhJRCgh1FYhiLAmdvX0CzTOpNE77ME0Zty/nWWzchDtiqrmQDeuv3powQ5ta2eN0FY0InkqDD73lT9c9lEzwUNqgFHs9VQce3TVClFCQrSTfOiYkVJQBmpbq2L6iZavPnAPcoU0dSw0SUTqz/GtrGuXfbyyBniKykOWQWGqwwMA7QiYAxi+IlPdqo+hYHnUt5ZPfnsHJyNiDtnpJyayNBkF6cWoYGAMY92U2hXHF/C1M8uP/ZtYdiuj26UdAdQQSXQErwSOMzt/XWRWAz5GuSBIkwG1H3FabJ2OsUOUhGC6tK4EMtJO0ttC6IBD3kM0ve0tJwMdSfjZo+EEISaeTr9P3wYrGjXqyC1krcKdhMpxEnt5JetoulscpyzhXN5FRpuPHvbeQaKxFAEB6EN+cYN6xD7RYGpXpNndMmZgM5Dcs3YSNFDHUo2LGfZuukSWyUYirJAdYbF3MfqEKmjM+I2EfhA94iG3L7uKrR+GdWD73ydlIB+6hgref1QTlmgmbM3/LeX5GI1Ux1RWpgxpLuZ2+I+IjzZ8wqE4nilvQdkUdfhzI5QDWy+kw5Wgg2pGpeEVeCCA7b85BO3F9DzxB3cdqvBzWcmzbyMiqhzuYqtHRVG2y4x+KOlnyqla8AoWWpuBoYRxzXrfKuILl6SfiWCbjxoZJUaCBj1CjH7GIaDbc9kqBY3W/Rgjda1iqQcOJu2WW+76pZC9QG7M00dffe9hNnseupFL53r8F7YHSwJWUKP2q+k7RdsxyOB11n0xtOvnW4irMMFNV4H0uqwS5ExsmP9AxbDTc9JwgneAT5vTiUSm1E7BSflSt3bfa1tv8Di3R8n3Af7MNWzs49hmauE2wP+ttrq+AsWpFG2awvsuOqbipWHgtuvuaAE+A1Z/7gC9hesnr+7wqCwG8c5yAg3AL1fm8T9AZtp/bbJGwl1pNrE7RuOX7PeMRUERVaPpEs+yqeoSmuOlokqw49pgomjLeh7icHNlG19yjs6XXOMedYm5xH2YxpV2tc0Ro2jJfxC50ApuxGob7lMsxfTbeUv07TyYxpeLucEH1gNd4IKH2LAg5TdVhlCafZvpskfncCfx8pOhJzd76bJWeYFnFciwcYfubRc12Ip/ppIhA1/mSZ/RxjFDrJC5xifFjJpY2Xl5zXdguFqYyTR1zSp1Y9p+tktDYYSNflcxI0iyO4TPBdlRcpeqjK/piF5bklq77VSEaA+z8qmJTFzIWiitbnzR794USKBUaT0NTEsVjZqLaFVqJoPN9ODG70IPbfBHKK+/q/AWR0tJzYHRULOa4MP+W/HfGadZUbfw177G7j/OGbIs8TahLyynl4X4RinF793Oz+BU0saXtUHrVBFT/DnA3ctNPoGbs4hRIjTok8i+algT1lTHi4SxFvONKNrgQFAq2/gFnWMXgwffgYMJpiKYkmW3tTg3ZQ9Jq+f8XN+A5eeUKHWvJWJ2sgJ1Sop+wwhqFVijqWaJhwtD8MNlSBeWNNWTa5Z5kPZw5+LbVT99wqTdx29lMUH4OIG/D86ruKEauBjvH5xy6um/Sfj7ei6UUVk4AIl3MyD4MSSTOFgSwsH/QJWaQ5as7ZcmgBZkzjjU1UrQ74ci1gWBCSGHtuV1H2mhSnO3Wp/3fEV5a+4wz//6qy8JxjZsmxxy5+4w9CDNJY09T072iKG0EnOS0arEYgXqYnXcYHwjTtUNAcMelOd4xpkoqiTYICWFq0JSiPfPDQdnt+4/wuqcXY47QILbgAAAABJRU5ErkJggg==);  background-color: #ffffff;
@@ -59,7 +106,7 @@ html {
 
 .footer-container {
   width: 100%;
-  text-align:center;
+  text-align: center;
   display: flex;
   justify-content: center;
 }
@@ -83,29 +130,26 @@ body {
 }
 
 #app {
-  font-family: 'Encode Sans', sans-serif;
+  font-family: "Encode Sans", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #06070a;
 }
 
 .route-link {
-  padding-right: 20px;
-  margin: 10px 10px 10px 10px;
-  padding-left: 20px;
+  margin: 10px;
+  padding: 0 20px;
   text-align: center;
   border: solid 1px;
   color: #026502;
   text-decoration: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-  word-wrap: break-word;
 }
 
 .nav {
   width: 100%;
-  word-break: break-all;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 .card:hover {
@@ -113,6 +157,7 @@ body {
 }
 
 .container {
+  position: relative;
   padding: 2px 16px;
 }
 
@@ -123,5 +168,4 @@ body {
 a {
   color: #7e6f20;
 }
-
 </style>

--- a/src/components/Accomodation.vue
+++ b/src/components/Accomodation.vue
@@ -1,21 +1,24 @@
 <template>
   <div class="page">
-    <br>
-    <p class="sleep-text">{{ $t("message.sleepText") }}</p>
-    <br>
+    <p class="sleep-text mb-2">{{ $t("message.sleepText") }}</p>
+
     <a href="https://goo.gl/maps/LLjYVUFyTsHP1DHp7">Hotels</a>
     <iframe
-        src="https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d59999.66220726317!2d29.059636338924086!3d37.78198185246777!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1sHotels!5e0!3m2!1sen!2sat!4v1632345098899!5m2!1sen!2sat"
-        width="100%"  height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
-    <br>
-    <br>
+    class="mb-1"
+      src="https://www.google.com/maps/embed?pb=!1m16!1m12!1m3!1d59999.66220726317!2d29.059636338924086!3d37.78198185246777!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!2m1!1sHotels!5e0!3m2!1sen!2sat!4v1632345098899!5m2!1sen!2sat"
+      width="100%"
+      height="450"
+      style="border:0;"
+      allowfullscreen=""
+      loading="lazy"
+    ></iframe>
   </div>
 </template>
 
 <script>
 export default {
-  name: "WhereToSleep"
-}
+  name: "WhereToSleep",
+};
 </script>
 
 <style scoped>

--- a/src/components/Arrival.vue
+++ b/src/components/Arrival.vue
@@ -1,118 +1,216 @@
 <template>
   <div>
-    <br>
     <div class="fact-head">
-      <p>{{ $t("message.arriveInfo") }}
-      <br>{{ $t("message.arriveInstruction") }}</p>
-      <p style="font-weight: bold; font-size: 1.2em"><a href='https://www.turkishairlines.com/'>Turkish Airlines</a>,
-      <a href='https://www.flypgs.com/ '>Pegasus Airlines</a>,
-      <a href='https://www.sunexpress.com/tr/ '>Sunexpress Airlines</a></p>
-      <p>{{ $t("message.arriveOneWay") }}</p>
+      <p>
+        {{ $t("message.arriveInfo") }} {{ $t("message.arriveInstruction") }}
+      </p>
+      <p style="font-weight: bold; font-size: 1.2em">
+        <a
+          href="https://www.turkishairlines.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Turkish Airlines</a
+        >,
+        <a
+          href="https://www.flypgs.com/ "
+          target="_blank"
+          rel="noopener noreferrer"
+          >Pegasus Airlines</a
+        >,
+        <a
+          href="https://www.sunexpress.com/tr/ "
+          target="_blank"
+          rel="noopener noreferrer"
+          >Sunexpress Airlines</a
+        >
+      </p>
+      <p class="mb-2">{{ $t("message.arriveOneWay") }}</p>
     </div>
     <div class="cards-page">
-      <br>
-      <br>
       <div class="card">
         <div class="container">
-          <h3><b>{{ $t("message.airplaneOnly") }}</b></h3>
+          <h3>
+            <b>{{ $t("message.airplaneOnly") }}</b>
+          </h3>
           <p>&#8611; {{ $t("message.airplaneOnlyText") }}</p>
           <p>&#8611; {{ $t("message.airplaneOnlyText1") }}</p>
           <p>&#8611; {{ $t("message.airplaneOnlyText2") }}</p>
-            <p>&#8611; {{ $t("message.airplaneOnlyText3") }}
-          </p>
-          <div class="fact-list">
+          <p>&#8611; {{ $t("message.airplaneOnlyText3") }}</p>
+          <div class="fact-list mb-2">
             <ul class="facts">
               <li>{{ $t("message.arriveKey1") }}</li>
-              <li><a
-                  href="https://www.google.com/travel/flights/search?tfs=CBwQAhojagwIAhIIL20vMGZocDkSCjIwMjEtMTItMDZyBwgBEgNETloaI2oHCAESA0ROWhIKMjAyMS0xMi0xMHIMCAISCC9tLzBmaHA5cAGCAQsI____________AUABSAGYAQE">{{
-                  $t("message.arriveKey4")
-                }}</a></li>
-              <li>{{ $t("message.airplaneOnlyBullet1")}}</li>
-              <li>{{ $t("message.airplaneOnlyBullet2")}} <a href='https://havaulasim.denizli.bel.tr/'>https://havaulasim.denizli.bel.tr/</a></li>
-              <li>{{ $t("message.airplaneOnlyBullet3")}}</li>
+              <li>
+                <a
+                  href="https://www.google.com/travel/flights/search?tfs=CBwQAhojagwIAhIIL20vMGZocDkSCjIwMjEtMTItMDZyBwgBEgNETloaI2oHCAESA0ROWhIKMjAyMS0xMi0xMHIMCAISCC9tLzBmaHA5cAGCAQsI____________AUABSAGYAQE"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >{{ $t("message.arriveKey4") }}</a
+                >
+              </li>
+              <li>{{ $t("message.airplaneOnlyBullet1") }}</li>
+              <li>
+                {{ $t("message.airplaneOnlyBullet2") }}
+                <a
+                  href="https://havaulasim.denizli.bel.tr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >https://havaulasim.denizli.bel.tr/</a
+                >
+              </li>
+              <li>{{ $t("message.airplaneOnlyBullet3") }}</li>
             </ul>
-            <br>
           </div>
         </div>
         <iframe
-            src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d5997839.809544202!2d18.414979790741636!3d42.7749722496872!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14c72153d6334ac9%3A0xae0ed24f9b70eb3e!2sDenizli%2C%20Turkey!3m2!1d37.6128395!2d29.2320784!5e0!3m2!1sen!2sat!4v1632342494672!5m2!1sen!2sat"
-            width="99%" height="450" style="border:solid grey 2px; margin-right: 3px; margin-left: 4px" allowfullscreen="" loading="lazy"></iframe>
-        <iframe src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d201741.24452646013!2d29.252673490905302!3d37.808621421807!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e0!4m5!1s0x14c6ee707e550963%3A0x7ef8a457dcec2fb8!2sDenizli%20Airport%2C%20Cumhuriyet%20Mah.%2C%20K%C3%BCme%20Evler%20Sok.%20No%3A1%2C%2020350%20%C3%87ardak%2FDenizli%2C%20Turkey!3m2!1d37.773965!2d29.690388199999997!4m5!1s0x14c73fb1353a6a69%3A0x2e3363fee62068ae!2zRGVuaXpsaSwgS3Vta8Sxc8SxaywgRGVuaXpsaSwgVHVya2V5!3m2!1d37.783015899999995!2d29.0963328!5e0!3m2!1sen!2sat!4v1647811407459!5m2!1sen!2sat" width="99%" height="450" style="border:solid grey 2px; margin-right: 5px" allowfullscreen="" loading="lazy"></iframe>
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d5997839.809544202!2d18.414979790741636!3d42.7749722496872!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14c72153d6334ac9%3A0xae0ed24f9b70eb3e!2sDenizli%2C%20Turkey!3m2!1d37.6128395!2d29.2320784!5e0!3m2!1sen!2sat!4v1632342494672!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d201741.24452646013!2d29.252673490905302!3d37.808621421807!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e0!4m5!1s0x14c6ee707e550963%3A0x7ef8a457dcec2fb8!2sDenizli%20Airport%2C%20Cumhuriyet%20Mah.%2C%20K%C3%BCme%20Evler%20Sok.%20No%3A1%2C%2020350%20%C3%87ardak%2FDenizli%2C%20Turkey!3m2!1d37.773965!2d29.690388199999997!4m5!1s0x14c73fb1353a6a69%3A0x2e3363fee62068ae!2zRGVuaXpsaSwgS3Vta8Sxc8SxaywgRGVuaXpsaSwgVHVya2V5!3m2!1d37.783015899999995!2d29.0963328!5e0!3m2!1sen!2sat!4v1647811407459!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
       </div>
     </div>
     <div class="cards-page">
-      <br>
-      <br>
       <div class="card">
         <div class="container">
-          <h3><b>{{ $t("message.planeAndTrain") }}</b></h3>
+          <h3>
+            <b>{{ $t("message.planeAndTrain") }}</b>
+          </h3>
           <p>&#8611; {{ $t("message.planeAndTrainText") }}</p>
           <p>&#8611; {{ $t("message.planeAndTrainText1") }}</p>
           <p>&#8611; {{ $t("message.planeAndTrainText2") }}</p>
           <div class="fact-list">
-            <ul class="facts">
-              <li>{{ $t("message.planeAndTrainBullet1")}}</li>
-              <li>{{ $t("message.planeAndTrainBullet2")}} <a href='https://railturkey.org/travel/trains/regional/izmirdenizli/'>Rail Turkey</a> - <a href='https://www.e-yasamrehberi.com/tren-saatleri/bolgesel-trenler/izmir-denizli-tren-saatleri.htm'>{{ $t("message.planeAndTrainBullet3")}}</a></li>
-              <li><a href='https://ebilet.tcddtasimacilik.gov.tr/view/eybis/tnmGenel/tcddWebContent.jsf'>{{ $t("message.planeAndTrainBullet4")}}</a></li>
+            <ul class="facts mb-2">
+              <li>{{ $t("message.planeAndTrainBullet1") }}</li>
+              <li>
+                {{ $t("message.planeAndTrainBullet2") }}
+                <a
+                  href="https://railturkey.org/travel/trains/regional/izmirdenizli/"
+                  >Rail Turkey</a
+                >
+                -
+                <a
+                  href="https://www.e-yasamrehberi.com/tren-saatleri/bolgesel-trenler/izmir-denizli-tren-saatleri.htm"
+                  >{{ $t("message.planeAndTrainBullet3") }}</a
+                >
+              </li>
+              <li>
+                <a
+                  href="https://ebilet.tcddtasimacilik.gov.tr/view/eybis/tnmGenel/tcddWebContent.jsf"
+                  >{{ $t("message.planeAndTrainBullet4") }}</a
+                >
+              </li>
             </ul>
-            <br>
           </div>
         </div>
-        <iframe src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d4993767.419757212!2d21.590934218896393!3d43.299772894749566!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14bbd862a762cacd%3A0x628cbba1a59ce8fe!2zxLB6bWlyLCBUdXJrZXk!3m2!1d38.423733999999996!2d27.142826!5e0!3m2!1sen!2sat!4v1647812151752!5m2!1sen!2sat" width="99%" height="450" style="border:solid grey 2px; margin-right: 3px; margin-left: 4px" allowfullscreen="" loading="lazy"></iframe>
-        <iframe src="https://www.google.com/maps/d/embed?mid=1kR2eES3VsW-Rb3wvxo817xcaZKrihUxT&ehbc=2E312F" width="99%" height="450" style="border:solid grey 2px; margin-right: 5px" allowfullscreen="" loading="lazy"></iframe>      </div>
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d4993767.419757212!2d21.590934218896393!3d43.299772894749566!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14bbd862a762cacd%3A0x628cbba1a59ce8fe!2zxLB6bWlyLCBUdXJrZXk!3m2!1d38.423733999999996!2d27.142826!5e0!3m2!1sen!2sat!4v1647812151752!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+        <iframe
+          src="https://www.google.com/maps/d/embed?mid=1kR2eES3VsW-Rb3wvxo817xcaZKrihUxT&ehbc=2E312F"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px; "
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+      </div>
     </div>
     <div class="cards-page">
-      <br>
-      <br>
       <div class="card">
         <div class="container">
-          <h3><b>{{ $t("message.planeAndBus") }}</b></h3>
-          <p> &#8611; {{ $t("message.planeAndBusText") }} </p>
-          <p>&#8611; {{ $t("message.planeAndBusText1") }} </p>
+          <h3>
+            <b>{{ $t("message.planeAndBus") }}</b>
+          </h3>
+          <p>&#8611; {{ $t("message.planeAndBusText") }}</p>
+          <p>&#8611; {{ $t("message.planeAndBusText1") }}</p>
           <p>&#8611; {{ $t("message.planeAndBusText2") }}</p>
-          <div class="fact-list">
+          <div class="fact-list mb-2">
             <ul class="facts">
-              <li>{{ $t("message.planeAndBusBullet1")}}</li>
-              <li>{{ $t("message.planeAndBusBullet2")}}</li>
-              <li>{{ $t("message.planeAndBusBullet3")}}</li>
+              <li>{{ $t("message.planeAndBusBullet1") }}</li>
+              <li>{{ $t("message.planeAndBusBullet2") }}</li>
+              <li>{{ $t("message.planeAndBusBullet3") }}</li>
             </ul>
-            <br>
           </div>
           <p>&#8611; {{ $t("message.planeAndBusText3") }}</p>
-          <div class="fact-list">
+          <div class="fact-list mb-2">
             <ul class="facts">
-              <li>{{ $t("message.planeAndBusText6")}}</li>
+              <li>{{ $t("message.planeAndBusText6") }}</li>
             </ul>
-            <br>
           </div>
-          <p><a href='https://www.pamukkale.com.tr/'>{{ $t("message.planeAndBusText4") }}</a> - <a href='https://www.flixbus.com.tr/'>{{ $t("message.planeAndBusText5") }}</a></p>
+          <p>
+            <a href="https://www.pamukkale.com.tr/">{{
+              $t("message.planeAndBusText4")
+            }}</a>
+            -
+            <a href="https://www.flixbus.com.tr/">{{
+              $t("message.planeAndBusText5")
+            }}</a>
+          </p>
         </div>
-        <iframe src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d6032376.084583575!2d19.157775379589726!3d42.41717331908884!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%201300%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14c39aaeddadadc1%3A0x95c69f73f9e32e33!2sAntalya%2C%20Turkey!3m2!1d36.8968908!2d30.7133233!5e0!3m2!1sen!2sat!4v1647818799370!5m2!1sen!2sat" width="99%" height="450" style="border:solid grey 2px; margin-right: 3px; margin-left: 4px" allowfullscreen="" loading="lazy"></iframe>
-        <iframe src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d51043.25160245236!2d30.699672539328233!3d36.90940511100648!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e3!4m5!1s0x14c384778d617c9d%3A0xc17cdcfcdb48e8fa!2zWWXFn2lsa8O2eSwgQW50YWx5YSBIYXZhbGltYW7EsSAoQVlUKSwgQW50YWx5YSBIYXZhYWxhbsSxIETEscWfIEhhdGxhciBUZXJtaW5hbGkgMSwgTXVyYXRwYcWfYS9BbnRhbHlhLCBUdXJrZXk!3m2!1d36.9043327!2d30.8018768!4m5!1s0x14c38e354576725f%3A0xcecde25fcafe69bc!2sAntalya%20Otogar%2C%20Yeni%20Do%C4%9Fan%2C%20Dumlup%C4%B1nar%20Bulvar%C4%B1%2C%20Kepez%2FAntalya%2C%20Turkey!3m2!1d36.9219443!2d30.6649809!5e0!3m2!1sen!2sat!4v1647818881412!5m2!1sen!2sat" width="99%" height="450" style="border:solid grey 2px; margin-right: 5px" allowfullscreen="" loading="lazy"></iframe>
-        <iframe src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d405791.4594105394!2d29.598518696454537!3d37.38401951583145!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e0!4m5!1s0x14c38e354576725f%3A0xcecde25fcafe69bc!2sAntalya%20Otogar%2C%20Yeni%20Do%C4%9Fan%2C%20Dumlup%C4%B1nar%20Bulvar%C4%B1%2C%20Kepez%2FAntalya%2C%20Turkey!3m2!1d36.9219443!2d30.6649809!4m5!1s0x14c73f7cc5f99983%3A0x1da19b281cdb5cd3!2sDenizli%20Otogar%C4%B1%2C%20Toprakl%C4%B1k%2C%2020150%20Pamukkale%2FDenizli%2C%20Turkey!3m2!1d37.7853557!2d29.0914197!5e0!3m2!1sen!2sat!4v1647818976155!5m2!1sen!2sat" width="99%" height="450" style="border:solid grey 2px; margin-right: 3px; margin-left: 4px" allowfullscreen="" loading="lazy"></iframe>      </div>
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d6032376.084583575!2d19.157775379589726!3d42.41717331908884!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e4!4m5!1s0x476c55ab471abe9b%3A0x247a52108dd29b4b!2sVienna%20International%20Airport%2C%201300%20Schwechat!3m2!1d48.1126125!2d16.5755139!4m5!1s0x14c39aaeddadadc1%3A0x95c69f73f9e32e33!2sAntalya%2C%20Turkey!3m2!1d36.8968908!2d30.7133233!5e0!3m2!1sen!2sat!4v1647818799370!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d51043.25160245236!2d30.699672539328233!3d36.90940511100648!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e3!4m5!1s0x14c384778d617c9d%3A0xc17cdcfcdb48e8fa!2zWWXFn2lsa8O2eSwgQW50YWx5YSBIYXZhbGltYW7EsSAoQVlUKSwgQW50YWx5YSBIYXZhYWxhbsSxIETEscWfIEhhdGxhciBUZXJtaW5hbGkgMSwgTXVyYXRwYcWfYS9BbnRhbHlhLCBUdXJrZXk!3m2!1d36.9043327!2d30.8018768!4m5!1s0x14c38e354576725f%3A0xcecde25fcafe69bc!2sAntalya%20Otogar%2C%20Yeni%20Do%C4%9Fan%2C%20Dumlup%C4%B1nar%20Bulvar%C4%B1%2C%20Kepez%2FAntalya%2C%20Turkey!3m2!1d36.9219443!2d30.6649809!5e0!3m2!1sen!2sat!4v1647818881412!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m28!1m12!1m3!1d405791.4594105394!2d29.598518696454537!3d37.38401951583145!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!4m13!3e0!4m5!1s0x14c38e354576725f%3A0xcecde25fcafe69bc!2sAntalya%20Otogar%2C%20Yeni%20Do%C4%9Fan%2C%20Dumlup%C4%B1nar%20Bulvar%C4%B1%2C%20Kepez%2FAntalya%2C%20Turkey!3m2!1d36.9219443!2d30.6649809!4m5!1s0x14c73f7cc5f99983%3A0x1da19b281cdb5cd3!2sDenizli%20Otogar%C4%B1%2C%20Toprakl%C4%B1k%2C%2020150%20Pamukkale%2FDenizli%2C%20Turkey!3m2!1d37.7853557!2d29.0914197!5e0!3m2!1sen!2sat!4v1647818976155!5m2!1sen!2sat"
+          width="99%"
+          height="450"
+          style="border:solid grey 2px;"
+          allowfullscreen=""
+          loading="lazy"
+        ></iframe>
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 export default {
-  name: "GetThere"
-}
+  name: "GetThere",
+};
 </script>
 
 <style scoped>
 .cards-page {
   max-width: 1080px;
-  margin: auto;
+  margin: 0 auto;
   justify-content: center;
+  margin-bottom: 50px;
 }
 
 .card {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.3s;
   width: 100%;
-  margin-right: 20px;
-  margin-bottom: 50px;
+  /* margin-right: 20px; */
+  
 }
 
 .facts {
@@ -123,10 +221,6 @@ export default {
 
 .fact-list {
   margin-right: 50px;
-}
-
-.station {
-  ;
 }
 
 .fact-head {

--- a/src/components/DenizliInfo.vue
+++ b/src/components/DenizliInfo.vue
@@ -1,33 +1,43 @@
 <template>
   <div>
-    <br>
-    <div class="fact-head">
+    <div class="fact-head mb-1">
       <p>{{ $t("message.sunscreen") }}</p>
       <p>{{ $t("message.badehose") }}</p>
       <p>{{ $t("message.denizliText") }}</p>
     </div>
-    <br>
     <div class="cards-page">
-      <br>
-      <br>
-      <div class="card">
-        <img src="pamukkale-white-beauty-1394441-1919x1274.jpg" alt="Avatar" style="width:100%">
+      <div class="card card--mr">
+        <img
+          src="pamukkale-white-beauty-1394441-1919x1274.jpg"
+          alt="Avatar"
+          style="width:100%"
+        />
         <div class="container">
-          <h4><b>{{ $t("message.denizliSprings") }}</b></h4>
+          <h4>
+            <b>{{ $t("message.denizliSprings") }}</b>
+          </h4>
           <p>{{ $t("message.denizliSprings") }}</p>
         </div>
       </div>
-      <div class="card">
-        <img src="ruins.jpg" alt="Avatar" style="width:100%">
+      <div class="card card--mr">
+        <img src="ruins.jpg" alt="Avatar" style="width:100%" />
         <div class="container">
-          <h4><b>{{ $t("message.denizliRoman") }}</b></h4>
+          <h4>
+            <b>{{ $t("message.denizliRoman") }}</b>
+          </h4>
           <p>{{ $t("message.denizliRoman") }}</p>
         </div>
       </div>
       <div class="card">
-        <img src="aydin-hassan-rnOdgU4EEWU-unsplash.jpg" alt="Avatar" style="width:100%">
+        <img
+          src="aydin-hassan-rnOdgU4EEWU-unsplash.jpg"
+          alt="Avatar"
+          style="width:100%"
+        />
         <div class="container">
-          <h4><b>{{ $t("message.denizliGöl") }}</b></h4>
+          <h4>
+            <b>{{ $t("message.denizliGöl") }}</b>
+          </h4>
           <p>{{ $t("message.denizliGöl") }}</p>
         </div>
       </div>
@@ -37,12 +47,13 @@
 
 <script>
 export default {
-  name: "GetThere"
-}
+  name: "GetThere",
+};
 </script>
 
-<style scoped>
+<style>
 .cards-page {
+  margin-top: 44px;
   max-width: 1400px;
   margin: auto;
   display: flex;
@@ -52,10 +63,11 @@ export default {
 .card {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.3s;
-  width: 31%;
-  margin-right: 20px;
+  width: 49%;
   margin-bottom: 50px;
 }
 
-
+.card--mr {
+  margin-right: 20px;
+}
 </style>

--- a/src/components/Language.vue
+++ b/src/components/Language.vue
@@ -1,20 +1,17 @@
 <template>
   <div class="page">
-    <br><br>
     <div class="fact-head">
-        <i18n path="message.dict" tag="p">
+      <i18n path="message.dict" tag="p">
         <br />
       </i18n>
     </div>
-    <br>
-    <br>
   </div>
 </template>
 
 <script>
 export default {
-  name: "Languanges"
-}
+  name: "Languanges",
+};
 </script>
 
 <style scoped>
@@ -22,7 +19,4 @@ export default {
   max-width: 700px;
   margin: auto;
 }
-
-
-
 </style>

--- a/src/components/Schedule.vue
+++ b/src/components/Schedule.vue
@@ -1,56 +1,42 @@
 <template>
   <div class="page">
-    <br>
     <div></div>
-    <br>
+
     <div class="cards-page">
-      <br>
-      <br>
-      <div class="card">
-        <img src="sunset-at-pamukkale-1314428.jpg" style="width:100%"/>
+      <div class="card card--mr">
+        <img src="sunset-at-pamukkale-1314428.jpg" style="width:100%" />
         <div class="container">
-          <h4><b>{{ $t("message.adaTitle") }}</b></h4>
+          <h4>
+            <b>{{ $t("message.adaTitle") }}</b>
+          </h4>
           <p>{{ $t("message.adaText") }}</p>
           <p><a href="https://goo.gl/maps/DUN2nUpcnpVyErG8A">Location</a></p>
         </div>
       </div>
       <div class="card">
-        <img src="oleksandr-kurchev-BGGgkws03KM-unsplash.jpg" style="width:100%"/>
+        <img
+          src="oleksandr-kurchev-BGGgkws03KM-unsplash.jpg"
+          style="width:100%"
+        />
         <div class="container">
-          <h4><b>{{ $t("message.bcnTitle") }}</b></h4>
+          <h4>
+            <b>{{ $t("message.bcnTitle") }}</b>
+          </h4>
           <p>{{ $t("message.bcnText") }}</p>
           <p><a href="https://goo.gl/maps/zyheQRyU5QPg8WaL9">Location</a></p>
         </div>
       </div>
     </div>
-    <br>
-    <br>
   </div>
 </template>
 
 <script>
 export default {
-  name: "GetThere"
-}
+  name: "GetThere",
+};
 </script>
 
 <style scoped>
-
-.cards-page {
-  max-width: 1400px;
-  margin: auto;
-  display: flex;
-  justify-content: center;
-}
-
-.card {
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  transition: 0.3s;
-  width: 49%;
-  margin-right: 20px;
-  margin-bottom: 50px;
-}
-
 .facts {
   width: 100%;
   align: left;

--- a/src/components/Welcome.vue
+++ b/src/components/Welcome.vue
@@ -43,8 +43,6 @@ a {
   font-family: 'Encode Sans', sans-serif;
   font-size: 1.5rem;
   margin-top: -30px;
-  margin-right: 5px;
-  margin-left: 5px;
   margin-bottom: 0px;
   color: #7e6f20;
 }


### PR DESCRIPTION
I mostly made it more semantic e.g. `header` and `main` instead of `div` `

`main` is important, I attached styles that makes it a centered container for all content, it seems to me that that's what you were trying to accomplish, I also put some padding, so it has some room to breathe.

Also I removed a lot of `br` elements, those should be used exclusively in breaking of the typography e.g. within `p` or other tag like that. I tried to keep it as similar to the original as I could. I introduced some helper `mb` classes e.g. `mb-1` is `margin-bottom:24px` analogously `mt-1` means `margin-top:24px`.  So just put it wherever you want to make a space.

Also the following is very important for reasonable layouting:
```CSS
* {
  box-sizing: border-box;
}
```
This is usually introduced in some reset solutions like [CSS reset](https://www.css-reset.com/) to reset styles for all browsers and make the styling intuitive.

Sorry for the formatting, that's what my editor did, hopefully not a problem.

